### PR TITLE
meshlayer legend management

### DIFF
--- a/glmesh.py
+++ b/glmesh.py
@@ -329,26 +329,20 @@ class ColorLegend(QGraphicsScene):
         Setter function to update min value legend
 
         """
-        try:
-            self.__minValue = float(value)
-            self.__checkValues()
-            self.__refresh()
-            self.symbologyChanged.emit()
-        except TypeError:
-            pass
+        self.__minValue = float(value)
+        self.__checkValues()
+        self.__refresh()
+        self.symbologyChanged.emit()
 
     def setMaxValue(self, value):
         """
         Setter function to update max value legend
 
         """
-        try:
-            self.__maxValue = float(value)
-            self.__checkValues()
-            self.__refresh()
-            self.symbologyChanged.emit()
-        except TypeError:
-            return
+        self.__maxValue = float(value)
+        self.__checkValues()
+        self.__refresh()
+        self.symbologyChanged.emit()
 
     def setTransparencyPercent(self, value):
         """
@@ -362,12 +356,9 @@ class ColorLegend(QGraphicsScene):
         Setter function to update transparency values
 
         """
-        try:
-            self.__transparency = float(value)
-            self.__refresh()
-            self.symbologyChanged.emit()
-        except ValueError:
-            return
+        self.__transparency = float(value)
+        self.__refresh()
+        self.symbologyChanged.emit()
 
     def setColorRamp(self, rampImageFile):
         """

--- a/glmesh.py
+++ b/glmesh.py
@@ -78,7 +78,7 @@ class ColorLegend(QGraphicsScene):
         self.__graduated = False
         self.__maskUnits = False
         self.__nbClass = len(self.__graduation)
-
+        self.tex = None
 
     @staticmethod
     def availableRamps():
@@ -334,8 +334,8 @@ class ColorLegend(QGraphicsScene):
             self.__checkValues()
             self.__refresh()
             self.symbologyChanged.emit()
-        except ValueError:
-            return
+        except TypeError:
+            pass
 
     def setMaxValue(self, value):
         """
@@ -347,7 +347,7 @@ class ColorLegend(QGraphicsScene):
             self.__checkValues()
             self.__refresh()
             self.symbologyChanged.emit()
-        except ValueError:
+        except TypeError:
             return
 
     def setTransparencyPercent(self, value):

--- a/glmesh.py
+++ b/glmesh.py
@@ -78,7 +78,7 @@ class ColorLegend(QGraphicsScene):
         self.__graduated = False
         self.__maskUnits = False
         self.__nbClass = len(self.__graduation)
-
+        self.tex = None
 
     @staticmethod
     def availableRamps():
@@ -93,7 +93,7 @@ class ColorLegend(QGraphicsScene):
         """
         return self.__graduated
 
-    def toggleGraduation(self, flag):
+    def toggleGraduation(self, flag, emit=True):
         """
         Activate or remove graduate symbology by sending pixelColor code.
 
@@ -109,13 +109,14 @@ class ColorLegend(QGraphicsScene):
             self.__pixelColor += "}\n";
         else:
             self.__pixelColor = ColorLegend.__pixelColorContinuous
-        self.symbologyChanged.emit()
+        if emit :
+            self.symbologyChanged.emit()
 
-    def setGraduation(self, graduation):
+    def setGraduation(self, graduation, emit=True):
         """graduation is a list of tuple (color, min, max) the alpha componant is not considered"""
         self.__graduation = graduation
         self.__nbClass =  len(graduation)
-        self.toggleGraduation(bool(self.__graduation))
+        self.toggleGraduation(bool(self.__graduation), emit)
 
     def graduation(self):
         """
@@ -267,7 +268,7 @@ class ColorLegend(QGraphicsScene):
                 grp.addToGroup(line)
         return grp
 
-    def setLogScale(self, trueOrFalse=True):
+    def setLogScale(self, trueOrFalse=True, emit=True):
         """
         Setter function to set linear/log scale
 
@@ -284,7 +285,7 @@ class ColorLegend(QGraphicsScene):
         """
         return self.__scale == "log"
 
-    def setTitle(self, text):
+    def setTitle(self, text, emit=True):
         """
         Setter function to set the legend title
 
@@ -301,12 +302,13 @@ class ColorLegend(QGraphicsScene):
         """
         return self.__title
 
-    def setUnits(self, text):
+    def setUnits(self, text, emit=True):
         """set the units to display in legend"""
         assert text is not None
         self.__units = text
         self.__refresh()
-        self.symbologyChanged.emit()
+        if emit :
+            self.symbologyChanged.emit()
 
     def units(self):
         return self.__units
@@ -324,7 +326,7 @@ class ColorLegend(QGraphicsScene):
             self.__minValue = max(self.__minValue, 1e-32)
             self.__maxValue = max(self.__maxValue, 1e-32)
 
-    def setMinValue(self, value):
+    def setMinValue(self, value, emit=True):
         """
         Setter function to update min value legend
 
@@ -333,11 +335,12 @@ class ColorLegend(QGraphicsScene):
             self.__minValue = float(value)
             self.__checkValues()
             self.__refresh()
-            self.symbologyChanged.emit()
-        except ValueError:
-            return
+            if emit :
+                self.symbologyChanged.emit()
+        except TypeError:
+            pass
 
-    def setMaxValue(self, value):
+    def setMaxValue(self, value, emit=True):
         """
         Setter function to update max value legend
 
@@ -346,8 +349,9 @@ class ColorLegend(QGraphicsScene):
             self.__maxValue = float(value)
             self.__checkValues()
             self.__refresh()
-            self.symbologyChanged.emit()
-        except ValueError:
+            if emit :
+                self.symbologyChanged.emit()
+        except TypeError:
             return
 
     def setTransparencyPercent(self, value):
@@ -369,7 +373,7 @@ class ColorLegend(QGraphicsScene):
         except ValueError:
             return
 
-    def setColorRamp(self, rampImageFile):
+    def setColorRamp(self, rampImageFile, emit=True):
         """
         Setter function to change the color ramp with a file path
 
@@ -377,7 +381,8 @@ class ColorLegend(QGraphicsScene):
         self.__colorRampFile = rampImageFile
         self.__colorRamp = QImage(rampImageFile)
         self.__refresh()
-        self.symbologyChanged.emit()
+        if emit :
+            self.symbologyChanged.emit()
 
     def transparencyPercent(self):
         """

--- a/meshlayerpropertydialog.py
+++ b/meshlayerpropertydialog.py
@@ -44,6 +44,8 @@ class MeshLayerPropertyDialog(QDialog):
         self.menu = QMenu(self.colorButton)
         self.colorButton.setMenu(self.menu)
         for name, fil in ColorLegend.availableRamps().items():
+            if fil[-14:] != 'continuous.svg':
+                continue
             img = QImage(fil).scaled(QSize(30,30))
             action = QAction(QIcon(QPixmap.fromImage(img)), name, self.colorButton)
             def emitter(f):
@@ -260,8 +262,10 @@ class MeshLayerPropertyDialog(QDialog):
         """
         if idx==0:
             self.layer.colorLegend().toggleGraduation(False)
+            self.colorButton.setIcon(QIcon(self.layer.colorLegend().colorRamp()))
         else:
             self.layer.colorLegend().toggleGraduation(True)
+            self.classColorButton.setIcon(QIcon(self.layer.colorLegend().colorRamp()))
 
 
 


### PR DESCRIPTION
The properties dialog didn't actualize the selected colorRamp between graduated and continuous legend.

And I removed try/except, this is already managed in the properties dialog. Finally I add `self.tex = None` in the __init__ function, otherwise the ColorLegend class is not fully created