### PR TITLE
fix wrong variable in setMaxValue

### DIFF
--- a/meshlayerpropertydialog.py
+++ b/meshlayerpropertydialog.py
@@ -131,7 +131,7 @@ class MeshLayerPropertyDialog(QDialog):
         """
         try :
             max = float(self.maxValue.text())
-            self.layer.colorLegend().setMaxValue(min)
+            self.layer.colorLegend().setMaxValue(max)
         except ValueError:
             pass
 


### PR DESCRIPTION
This commit should has been in the previous merge request, but apparently I forgot to push it.

There was a wrong variable in the properties dialog, in the setMaxValue function.